### PR TITLE
Update to firebase 7.3.1 and split up targets

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,38 +3,38 @@
     "pins": [
       {
         "package": "abseil",
-        "repositoryURL": "https://github.com/firebase/abseil-cpp.git",
+        "repositoryURL": "https://github.com/firebase/abseil-cpp-SwiftPM.git",
         "state": {
           "branch": null,
-          "revision": "d30bd7751ce343a05fca6413de0dec062163e5e9",
-          "version": null
+          "revision": "05d8107f2971a37e6c77245b7c4c6b0a7e97bc99",
+          "version": "0.20200225.0"
         }
       },
       {
         "package": "BoringSSL-GRPC",
-        "repositoryURL": "https://github.com/firebase/boringssl.git",
+        "repositoryURL": "https://github.com/firebase/boringssl-SwiftPM.git",
         "state": {
           "branch": null,
-          "revision": "897ffb6fbb5a5ea149216d664ce8b04d77e3df22",
-          "version": null
+          "revision": "7bcafa2660bc58715c39637494550d1ed7cd7229",
+          "version": "0.0.7"
         }
       },
       {
         "package": "Firebase",
         "repositoryURL": "https://github.com/firebase/firebase-ios-sdk.git",
         "state": {
-          "branch": "6.32-spm-beta",
-          "revision": "08b856762f7301a65836e042eccab0d4c0f93889",
-          "version": null
+          "branch": null,
+          "revision": "c67d97dc802aafe5474042156dce828e1c4145ca",
+          "version": "7.3.1"
         }
       },
       {
         "package": "gRPC",
-        "repositoryURL": "https://github.com/firebase/grpc.git",
+        "repositoryURL": "https://github.com/firebase/grpc-SwiftPM.git",
         "state": {
           "branch": null,
-          "revision": "cae939a8823bbc39912aa2990cf95e29ace381b3",
-          "version": null
+          "revision": "91b62619e6c83bc5f1b99d9d60fe46b2862d3a5a",
+          "version": "1.28.2"
         }
       },
       {
@@ -51,17 +51,17 @@
         "repositoryURL": "https://github.com/firebase/leveldb.git",
         "state": {
           "branch": null,
-          "revision": "3f046978ecffd57ea6eb9a0897cc8a3b45b44df8",
-          "version": null
+          "revision": "fa1f25f296a766e5a789c4dacd4798dea798b2c2",
+          "version": "1.22.1"
         }
       },
       {
         "package": "nanopb",
-        "repositoryURL": "https://github.com/nanopb/nanopb.git",
+        "repositoryURL": "https://github.com/firebase/nanopb.git",
         "state": {
           "branch": null,
-          "revision": "3cfa21200eea012d8765239ad4c50d8a36c283f1",
-          "version": null
+          "revision": "8119dfe5631f2616d11e50ead95448d12e816062",
+          "version": "2.30906.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -11,27 +11,90 @@ let package = Package(
             name: "CombineFirebase",
             targets: ["CombineFirebase"]
         ),
+        .library(
+            name: "CombineFirebaseAuth",
+            targets: ["CombineFirebaseAuth"]
+        ),
+        .library(
+            name: "CombineFirebaseDatabase",
+            targets: ["CombineFirebaseDatabase"]
+        ),
+        .library(
+            name: "CombineFirebaseFirestore",
+            targets: ["CombineFirebaseFirestore"]
+        ),
+        .library(
+            name: "CombineFirebaseFunctions",
+            targets: ["CombineFirebaseFunctions"]
+        ),
+        .library(
+            name: "CombineFirebaseRemoteConfig",
+            targets: ["CombineFirebaseRemoteConfig"]
+        ),
+        .library(
+            name: "CombineFirebaseStorage",
+            targets: ["CombineFirebaseStorage"]
+        ),
     ],
     dependencies: [
-        .package(
-            name: "Firebase",
-            url: "https://github.com/firebase/firebase-ios-sdk.git",
-            .branch("6.32-spm-beta")
-        ),
+        .package(name: "Firebase", url: "https://github.com/firebase/firebase-ios-sdk.git", from: "7.3.1"),
     ],
     targets: [
         .target(
             name: "CombineFirebase",
             dependencies: [
-                .product(name: "FirebaseAuth", package: "Firebase"),
-                .product(name: "FirebaseDatabase", package: "Firebase"),
-                .product(name: "FirebaseFirestore", package: "Firebase"),
-                .product(name: "FirebaseFirestoreSwift", package: "Firebase"),
-                .product(name: "FirebaseFunctions", package: "Firebase"),
-                .product(name: "FirebaseRemoteConfig", package: "Firebase"),
-                .product(name: "FirebaseStorage", package: "Firebase"),
+                "CombineFirebaseAuth",
+                "CombineFirebaseDatabase",
+                "CombineFirebaseFirestore",
+                "CombineFirebaseFunctions",
+                "CombineFirebaseRemoteConfig",
+                "CombineFirebaseStorage",
             ],
-            path: "Sources"
+            path: "Sources/Core"
+        ),
+        .target(
+            name: "CombineFirebaseAuth",
+            dependencies: [
+                .product(name: "FirebaseAuth", package: "Firebase"),
+            ],
+            path: "Sources/Auth"
+        ),
+        .target(
+            name: "CombineFirebaseDatabase",
+            dependencies: [
+                .product(name: "FirebaseDatabase", package: "Firebase"),
+            ],
+            path: "Sources/Database"
+        ),
+        .target(
+            name: "CombineFirebaseFirestore",
+            dependencies: [
+                .product(name: "FirebaseFirestore", package: "Firebase"),
+                .product(name: "FirebaseFirestoreSwift-Beta", package: "Firebase"),
+            ],
+            path: "Sources/Firestore"
+        ),
+        .target(
+            name: "CombineFirebaseFunctions",
+            dependencies: [
+                .product(name: "FirebaseFunctions", package: "Firebase"),
+            ],
+            path: "Sources/Functions"
+        ),
+        .target(
+            name: "CombineFirebaseRemoteConfig",
+            dependencies: [
+                .product(name: "FirebaseRemoteConfig", package: "Firebase"),
+            ],
+            path: "Sources/RemoteConfig"
+        ),
+        .target(
+            name: "CombineFirebaseStorage",
+            dependencies: [
+                .product(name: "FirebaseStorage", package: "Firebase"),
+                .product(name: "FirebaseStorageSwift-Beta", package: "Firebase")
+            ],
+            path: "Sources/Storage"
         )
     ]
 )


### PR DESCRIPTION
- Updated firebase to latest release
- Split up packages so we don't have to include all of firebase if we only want a certain piece 