### PR TITLE
Updated package.swift to enable firebase v8

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(name: "Firebase", url: "https://github.com/firebase/firebase-ios-sdk.git", from: "7.3.1"),
+        .package(name: "Firebase", url: "https://github.com/firebase/firebase-ios-sdk.git", "7.3.1"..<"9.0.0"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
The change makes it possible to use it with Firebase v8.x.x by Swift Package Manager